### PR TITLE
remove sidekiq and move jobs from controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ gem 'redis', '~> 4.0'
 gem 'cloudinary', '~> 1.16.0'
 
 # Use sidekiq
-gem 'sidekiq'
-gem 'sidekiq-failures', '~> 1.0'
+# gem 'sidekiq'
+# gem 'sidekiq-failures', '~> 1.0'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,6 @@ GEM
       rest-client
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    connection_pool (2.2.3)
     crass (1.0.6)
     debug_inspector (1.0.0)
     devise (4.7.3)
@@ -220,12 +219,6 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.1)
-    sidekiq (6.1.3)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.2.0)
-    sidekiq-failures (1.0.0)
-      sidekiq (>= 4.0.0)
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -297,8 +290,6 @@ DEPENDENCIES
   redis (~> 4.0)
   sass-rails (>= 6)
   selenium-webdriver
-  sidekiq
-  sidekiq-failures (~> 1.0)
   simple_form
   spring
   turbolinks (~> 5)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -76,9 +76,6 @@ class SearchesController < ApplicationController
   def set_vars_from_params
     # @query [ "123", "1231", "123" ] is an array that stores the ids we need to use to call the api
     @query = user_params[:search][:queries].strip.split("&")
-    MovieInfoJob.perform_later(@query)
-    CastMatcherJob.perform_later(@query)
-    # MovieRecommendationJob is called from MovieInfoJob
   end
 
   def search_results(query)

--- a/app/jobs/movie_info_job.rb
+++ b/app/jobs/movie_info_job.rb
@@ -11,7 +11,7 @@ class MovieInfoJob < ApplicationJob
           partial: "shared/cards/movie_card",
           locals: { movie: movie } }
       )
-      MovieRecommendationJob.perform_later(movie, query) if movie == movies.last
+      MovieRecommendationJob.perform_now(movie, query) if movie == movies.last
     end
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -16,6 +16,6 @@ class Search < ApplicationRecord
   end
 
   def async_update
-    CallApiJob.perform_later(id)
+    CallApiJob.perform_now(id)
   end
 end

--- a/app/services/face_recognition.rb
+++ b/app/services/face_recognition.rb
@@ -4,7 +4,7 @@ class FaceRecognition
   @face_url = "https://wthactorsname-tdevy3cs7a-ew.a.run.app/find_actor_by_pic"
 
   def self.call(result)
-    FaceRecognitionJob.perform_later(
+    FaceRecognitionJob.perform_now(
       @face_url,
       result.id
     )

--- a/app/views/searches/home.html.erb
+++ b/app/views/searches/home.html.erb
@@ -16,6 +16,7 @@
                 </p>
 
         <% else %>
+    
                     <!-- if there already has been movie input -->
                     <div id="movie-card-section" data-cable-id="<%= params[:search][:queries] %>">
                         <%= render "shared/cards/movie_cards" %>
@@ -40,8 +41,13 @@
               <%= render 'shared/navigation/footer' %>
             <% end %>
 
+        <% MovieInfoJob.perform_later(@query) %>
+        <% CastMatcherJob.perform_later(@query) %>
+        
         <% end %>
+
     </div>
+
 
     <% if @query.empty? %>
         <div class="cover"></div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module WhatTheHell
   class Application < Rails::Application
     # enable unobstrusive javascript
     config.action_view.embed_authenticity_token_in_remote_forms = true
-    config.active_job.queue_adapter = :sidekiq
+    # config.active_job.queue_adapter = :sidekiq
 
     config.generators do |generate|
       generate.assets false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,4 @@ Rails.application.routes.draw do
   resources :searches, only: :create
   resources :results, only: :show
 
-  # Sidekiq Web UI, only for admins.
-  require "sidekiq/web"
-  authenticate :user, ->(user) { user.admin? } do
-    mount Sidekiq::Web => '/sidekiq'
-  end
 end


### PR DESCRIPTION
Initial experiment with removing `sidekiq` background job management and removing API calls from the controller to try and avoid the issue of these calls completing too quickly to be received by `ActionCable` on Heroku.